### PR TITLE
some sizes and margins for "people"

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -15,7 +15,7 @@ img.portait {
     width: 80%;
     border-radius: 50%;
     margin-top: 3rem;
-    max-width: 300px;
+    max-width: 200px;
 }
 
 div.person {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -9,16 +9,36 @@ p {
     text-align: justify;
 }
 
+/* let portraits grow up to their max size */
 img.portait {
-    width: 150px;
+    display: block;
+    width: 80%;
     border-radius: 50%;
+    margin-top: 3rem;
+    max-width: 300px;
 }
 
 div.person {
     margin-bottom: 30px;
+
+    .page-content {
+        margin-top: 20px;
+    }
+    .position {
+        font-weight: bolder;
+    }
 }
-div.person .page-content {
-    margin-top: 20px;
+
+#homepageTeamPic {
+    margin-top: 1rem;
+}
+
+@include media-breakpoint-down(sm) {
+    div.person {
+        img.portait {
+            margin: 0 auto;
+        }
+    }
 }
 
 @include media-breakpoint-up(lg) {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -9,7 +9,8 @@ $container-max-widths: (
   sm: 540px,
   md: 640px,
   lg: 800px,
-  xl: 900px
+  xl: 900px,
+  xxl: 70em
 ) !default;
 
 // Minty 4.3.1

--- a/index.md
+++ b/index.md
@@ -2,9 +2,9 @@
 layout: page
 title: About the Lab
 ---
-The Landgraf Lab works at the interface of biology and computer science to study the collective intelligence of model organisms (bees and fish). To understand how the various interactions between the members of a group lead to emergent group properties, we develop modern tools such as tracking systems or biomimetic robots. Using these tools, we have been able to record large and unique data sets. An integral part of the lab is the development of interpretable machine learning models that provide explanations as to what they have learned. This ultimately informs new hypotheses, new experiments and new tools to be developed in the future. 
+The Landgraf Lab works at the interface of biology and computer science to study the collective intelligence of model organisms (bees and fish). To understand how the various interactions between the members of a group lead to emergent group properties, we develop modern tools such as tracking systems or biomimetic robots. Using these tools, we have been able to record large and unique data sets. An integral part of the lab is the development of interpretable machine learning models that provide explanations as to what they have learned. This ultimately informs new hypotheses, new experiments and new tools to be developed in the future.
 
-<img src="./assets/images/lab_photo.png"/>
+<img src="./assets/images/lab_photo.png" id="homepageTeamPic"/>
 
 ##  Collaborators
 
@@ -15,5 +15,3 @@ The Landgraf Lab works at the interface of biology and computer science to study
 * [Prof. Dr. Gerhard von der Emde](https://www.zoologie.uni-bonn.de/abteilungen/neuroethologie-sensorische-oekologie-prof.-g.-von-der-emde), Neuroethology, Uni Bonn
 * [Prof. Dr. Iain Couzin](https://collectivebehaviour.com/people/couzin-iain/) - MPI Animal Behavior and Uni Konstanz
 * [Prof. Dr. Michael Smith](https://smithbeelab.com/pages/people/) - Auburn University
-
-

--- a/people.html
+++ b/people.html
@@ -5,11 +5,16 @@ title: People
 
   {% for person in site.people %}
       <div class="row person">
-          <div class="col-3">
+          <div class="col-12 col-md-4">
               <img class="portait" src="{{ person.image }}"/>
           </div>
-          <div class="col-8">
+          <div class="col-md-8">
               <h2>{{ person.name }}</h2>
+
+              <div class='position'>
+                {{ person.position }}
+              </div>
+
               {{ person.email }}
               {% if person.twitter %}
               <a href="https://www.twitter.com/{{ person.twitter }}">Twitter</a>
@@ -20,10 +25,6 @@ title: People
               {% if person.github %}
               <a href="https://github.com/{{ person.github }}">Github</a>
               {% endif  %}
-
-              <div class='person-position'>
-                {{ person.position }}
-              </div>
 
               <div class="page-content">
                 {{ person.content | markdownify }}


### PR DESCRIPTION
* give team pic on home page some space
* let portraits move atop on small screens
* move people's position to the top and add a little emphasis
* add new 70em xxl breakpoint
* let portraits grow up to their maximum size